### PR TITLE
Replace :: with __ in THIS like it's done for parameters/return values

### DIFF
--- a/lib/ExtUtils/ParseXS.pm
+++ b/lib/ExtUtils/ParseXS.pm
@@ -579,7 +579,7 @@ EOF
           } );
         }
         else {
-          print "\t$class *";
+          print "\t" . map_type($self, "$class *");
           $self->{var_types}->{"THIS"} = "$class *";
           $self->generate_init( {
             type          => "$class *",


### PR DESCRIPTION
Apart from being more consistent, this simplifies writing XS code wrapping C++
classes into a nested Perl namespace (it reqquires only a typedef for Foo__Bar
rather than two, one for Foo_Bar and the other for Foo::Bar).

Impact is likely to be minimmal: it will only affect classes:
- in C++ extensions (there is no way to make Foo::Bar *THIS compile in C)
- that use Foo::Bar only as a receiver (if they use it as a parameter/return value
  the typedef is already there)

Given that a class is always used as the return valus in a normal constructor, this
case should be relatively rare.

given this Foo.xs file:

    MODULE=Foo PACKAGE=Foo::Bar

    TYPEMAP: <<EOT
    TYPEMAP
    Foo::Bar * T_PTRREF
    EOT

    Foo::Bar *
    Foo::Bar::moo(Foo::Bar *foo)

the output of

     perl -Ilib lib/ExtUtils/xsubpp -prototypes Foo.xs | grep -A8 moo | head -n 10

changes from:

    XS_EUPXS(XS_Foo__Bar_moo); /* prototype to pass -Wmissing-prototypes */
    XS_EUPXS(XS_Foo__Bar_moo)
    {
        dVAR; dXSARGS;
        if (items != 2)
            croak_xs_usage(cv,  "THIS, foo");
        {
            Foo::Bar *      THIS;
            Foo__Bar *      RETVAL;
            Foo__Bar *      foo;

to:

    XS_EUPXS(XS_Foo__Bar_moo); /* prototype to pass -Wmissing-prototypes */
    XS_EUPXS(XS_Foo__Bar_moo)
    {
        dVAR; dXSARGS;
        if (items != 2)
           croak_xs_usage(cv,  "THIS, foo");
        {
            Foo__Bar *      THIS;
            Foo__Bar *      RETVAL;
            Foo__Bar *      foo;