### PR TITLE
Allow User-supplied typemaps to take precedence

### DIFF
--- a/lib/ExtUtils/ParseXS/Utilities.pm
+++ b/lib/ExtUtils/ParseXS/Utilities.pm
@@ -272,7 +272,7 @@ sub process_typemaps {
     die "Can't find $typemap in $pwd\n" unless -r $typemap;
   }
 
-  push @tm, standard_typemap_locations( \@INC );
+  unshift @tm, standard_typemap_locations( \@INC );
 
   require ExtUtils::Typemaps;
   my $typemap = ExtUtils::Typemaps->new;

--- a/t/106-process_typemaps.t
+++ b/t/106-process_typemaps.t
@@ -41,3 +41,82 @@ my $startdir  = cwd();
     chdir $startdir;
 }
 
+
+
+## Make sure that the entries in last-most typemap files listed in the
+## array-ref passed to process_typemaps() actually take precedence over
+## the entries in the files that come before.
+##
+## The next two test blocks will verify that this is working properly.
+
+
+# A user-supplied file should take precedence over any global typemaps.
+{
+    my @tfiles = (
+       [ 'typemap-foo' => "TYPEMAP\n".
+                          "int            T_FOO_INT\n" ]
+    );
+    
+    my $typemap = [ 'typemap-foo' ];
+    my $tdir = tempdir( CLEANUP => 1 );
+    chdir $tdir or croak "Unable to change to tempdir for testing";
+    
+    for (@tfiles) {
+       open my $fh, '>', $_->[0] or croak "Cannot open for writing";
+       print $fh $_->[1];
+       close $fh or croak "Cannot close after writing";
+    }
+    
+    my $t; 
+    eval { $t = process_typemaps( $typemap, $tdir ) };
+    
+    croak "Got invalid object from process_typemaps()"
+       unless ref($t) eq 'ExtUtils::Typemaps';
+    
+    my $xs_int_type  = $t->get_typemap(ctype => 'int')->xstype;
+    my $xs_uint_type = $t->get_typemap(ctype => 'unsigned int')->xstype;
+    
+    like($xs_int_type, qr/T_FOO_INT/, # From 'typemap-foo' file.
+       'Last typemap file passed to process_typemaps() takes precedence'
+    );
+    
+    chdir $startdir;
+}
+
+
+# A user-supplied file should take precedence over a root 'typemap' file.
+{
+    my @tfiles = (
+       [ 'typemap'     => "TYPEMAP\n".
+                          "int            T_ROOT_INT\n" ],
+       
+       [ 'typemap-foo' => "TYPEMAP\n".
+                          "int            T_FOO_INT\n" ]
+    );
+    
+    my $typemap = [ 'typemap-foo' ];
+    my $tdir = tempdir( CLEANUP => 1 );
+    chdir $tdir or croak "Unable to change to tempdir for testing";
+    
+    for (@tfiles) {
+       open my $fh, '>', $_->[0] or croak "Cannot open for writing";
+       print $fh $_->[1];
+       close $fh or croak "Cannot close after writing";
+    }
+    
+    my $t; 
+    eval { $t = process_typemaps( $typemap, $tdir ) };
+    
+    croak "Got invalid object from process_typemaps()"
+       unless ref($t) eq 'ExtUtils::Typemaps';
+    
+    my $xs_int_type  = $t->get_typemap(ctype => 'int')->xstype;
+    my $xs_uint_type = $t->get_typemap(ctype => 'unsigned int')->xstype;
+    
+    like($xs_int_type, qr/T_FOO_INT/, # From 'typemap-foo' file.
+       'Last typemap file passed to process_typemaps() takes precedence'
+    );
+    
+    chdir $startdir;
+}
+

--- a/t/106-process_typemaps.t
+++ b/t/106-process_typemaps.t
@@ -74,9 +74,8 @@ my $startdir  = cwd();
        unless ref($t) eq 'ExtUtils::Typemaps';
     
     my $xs_int_type  = $t->get_typemap(ctype => 'int')->xstype;
-    my $xs_uint_type = $t->get_typemap(ctype => 'unsigned int')->xstype;
     
-    like($xs_int_type, qr/T_FOO_INT/, # From 'typemap-foo' file.
+    cmp_ok($xs_int_type, 'eq', 'T_FOO_INT', # From 'typemap-foo' file.
        'Last typemap file passed to process_typemaps() takes precedence'
     );
     
@@ -111,9 +110,8 @@ my $startdir  = cwd();
        unless ref($t) eq 'ExtUtils::Typemaps';
     
     my $xs_int_type  = $t->get_typemap(ctype => 'int')->xstype;
-    my $xs_uint_type = $t->get_typemap(ctype => 'unsigned int')->xstype;
     
-    like($xs_int_type, qr/T_FOO_INT/, # From 'typemap-foo' file.
+    cmp_ok($xs_int_type, 'eq', 'T_FOO_INT', # From 'typemap-foo' file.
        'Last typemap file passed to process_typemaps() takes precedence'
     );
     


### PR DESCRIPTION
According to

https://github.com/Perl-Toolchain-Gang/extutils-parsexs/blob/master/README#L64-L68:

>       typemap
>            Indicates that a user-supplied typemap should take precedence
>            over the default typemaps. A single typemap may be specified as
>            a string, or multiple typemaps can be specified in an array
>            reference, with the last typemap having the highest precedence.

the last element of the array-ref passed to `ExtUtils::ParseXS::Utilities::process_typemaps` should be taking precedence, as `ExtUtils::ParseXS::process_file` just passes it's `$args{typemap}` to `process_typemaps`, shown here:

https://github.com/Perl-Toolchain-Gang/extutils-parsexs/blob/29e5a1ef39513ff5815b3faf8fe8b47d68c72e9a/lib/ExtUtils/ParseXS.pm#L175


But passed typemaps are not actually taking precedence unless it's named 'typemap' and appears in one of the locations listed here:

https://github.com/Perl-Toolchain-Gang/extutils-parsexs/blob/29e5a1ef39513ff5815b3faf8fe8b47d68c72e9a/lib/ExtUtils/ParseXS/Utilities.pm#L102-L111


The problem is, `standard_typemap_locations( \@INC )`, shown here

https://github.com/Perl-Toolchain-Gang/extutils-parsexs/blob/29e5a1ef39513ff5815b3faf8fe8b47d68c72e9a/lib/ExtUtils/ParseXS/Utilities.pm#L275

is `push()`ed to the end of the typemap array, `@tm`, and since the last-most entries take precedence, it's not possible for the supplied typemaps to override entries returned by `standard_typemap_locations()`.

`unshift()`ing instead of `push()`ing would allow supplied typemaps to properly take precedence.

The reason this probably went unnoticed for so long is most likely due to the problem only occurring when overriding a typemap defined in `perl -V:privlib`/ExtUtils/typemap.

For example, when **./typemap-foo** and `perl -V:privlib`**/ExtUtils/typemap** both define a mapping for the same data type, the definition in `perl -V:privlib`**/ExtUtils/typemap**, which is processed after **./typemap-foo**, is the one that is used because the last one wins.

When *./typemap-foo* defines type mappings that are not found in `perl -V:privlib`**/ExtUtils/typemap** (or anywhere else returned by `standard_typemap_locations()`) then they are merged in just fine since they don't exist in `perl -V:privlib`**/ExtUtils/typemap** and thus don't get clobbered.


### Here are examples that demonstrate the problem in ExtUtils::ParseXS 3.35 or earlier. (Run these commands in an empty directory.)

##### Note: `ExtUtils::ParseXS::Utilities::process_typemaps([@ARGV], pwd)` in the examples below are based on this line:
https://github.com/Perl-Toolchain-Gang/extutils-parsexs/blob/29e5a1ef39513ff5815b3faf8fe8b47d68c72e9a/lib/ExtUtils/ParseXS.pm#L175


#### Linux/Unix

`\rm typemap*; echo -e 'TYPEMAP\nwchar_t * T_WCHAR' > typemap; perl -MExtUtils::ParseXS::Utilities -E 'say ExtUtils::ParseXS::Utilities::process_typemaps([@ARGV], pwd)->as_string' typemap | grep -i wchar`
wchar_t T_IV
wchar_t *       T_WCHAR

`\rm typemap*; echo -e 'TYPEMAP\nwchar_t * T_WCHAR' > typemap-other; perl -MExtUtils::ParseXS::Utilities -E 'say ExtUtils::ParseXS::Utilities::process_typemaps([@ARGV], pwd)->as_string' typemap-other | grep -i wchar`
wchar_t *       T_PV
wchar_t T_IV


#### Win32:

`del typemap* & echo TYPEMAP > typemap & echo wchar_t * T_WCHAR >> typemap & perl -MExtUtils::ParseXS::Utilities -E "say ExtUtils::ParseXS::Utilities::process_typemaps([@ARGV], pwd)->as_string" typemap | grep -i wchar`
wchar_t T_IV
wchar_t *       T_WCHAR

`del typemap* & echo TYPEMAP > typemap-other & echo wchar_t * T_WCHAR >> typemap-other & perl -MExtUtils::ParseXS::Utilities -E "say ExtUtils::ParseXS::Utilities::process_typemaps([@ARGV], pwd)->as_string" typemap-other | grep -i wchar`
wchar_t *       T_PV
wchar_t T_IV

##### `wchar_t * T_PV` is defined in `perl -V:privlib`*/ExtUtils/typemap* so in the examples using *typemap-other* instead of *typemap*, it overrides the user-supplied `wchar_t * T_WCHAR` entry.